### PR TITLE
Make Caches Recursion Breaking

### DIFF
--- a/crates/rustc_utils/src/cache.rs
+++ b/crates/rustc_utils/src/cache.rs
@@ -1,4 +1,21 @@
-//! Data structure for memoizing computations.
+//! Data structures for memoizing computations.
+//! 
+//! Contruct new caches using [`Default::default`], then construct/retrieve
+//! elements with `get`.
+//! 
+//! In terms of choice, 
+//! - [`CopyCache`] should be used for expensive computations that create cheap
+//!   (i.e. small) values.
+//! - [`Cache`] should be used for expensive computations that create expensive
+//!   (i.e. large) values.
+//! - [`RecursionBreakingCache`] is the same as [`Cache`] except that it should
+//!   be used if the construction function for your values is going to call
+//!   `get` on the same cache. It detects if such a call is made with the same
+//!   key, which causes infinite recursion when [`Cache`] is used.
+//! 
+//! When in doubt the safest version is [`RecursionBreakingCache`] and if you
+//! don't anticipate recursion to occur you can always call `unwrap()` on it's
+//! result.
 
 use std::{cell::RefCell, hash::Hash, mem, pin::Pin};
 
@@ -11,6 +28,7 @@ impl<In, Out> Cache<In, Out>
 where
   In: Hash + Eq + Clone,
 {
+  /// Size of the cache
   pub fn len(&self) -> usize {
     self.0.borrow().len()
   }
@@ -47,6 +65,7 @@ where
   In: Hash + Eq + Clone,
   Out: Copy,
 {
+  /// Size of the cache
   pub fn len(&self) -> usize {
     self.0.borrow().len()
   }
@@ -77,6 +96,7 @@ where
   In: Hash + Eq + Clone,
   Out: Unpin,
 {
+  /// Size of the cache
   pub fn len(&self) -> usize {
     self.0.borrow().len()
   }

--- a/crates/rustc_utils/src/cache.rs
+++ b/crates/rustc_utils/src/cache.rs
@@ -141,7 +141,7 @@ where
 
     *self.0.borrow_mut()
       .get(&key)
-      .expect("invariant proken")
+      .expect("invariant broken")
   }
 }
 

--- a/crates/rustc_utils/src/cache.rs
+++ b/crates/rustc_utils/src/cache.rs
@@ -23,14 +23,23 @@
 //! [`CopyCache`]:
 //!
 //! ```rs
-//! let cache = CopyCache::default();
-//! let next_fib = |this| {
-//!   if this <= 1 { return this; }
-//!   let fib_1 = cache.get(this - 1, next_fib);
-//!   let fib_2 = cache.get(this - 2, next_fib);
-//!   fib_1 + fib_2
-//! };
-//! let fib_5 = cache.get(5, next_fib);
+//! struct Fib(CopyCache<u32, u32>);
+//! 
+//! impl Fib {
+//!   fn get(&self, i: u32) -> u32 {
+//!     self.0.get(i, |_| {
+//!       if this <= 1 {
+//!         return this;
+//!       }
+//!       let fib_1 = self.get(this - 1);
+//!       let fib_2 = self.get(this - 2);
+//!       fib_1 + fib_2
+//!     })
+//!   }
+//! }
+//! 
+//! let cache = Fib(Default::default());
+//! let fib_5 = cache.get(5);
 //! ```
 //!
 //! This use of recursive [`get`](CopyCache::get) calls is perfectly legal.

--- a/crates/rustc_utils/src/cache.rs
+++ b/crates/rustc_utils/src/cache.rs
@@ -1,28 +1,60 @@
 //! Data structures for memoizing computations.
 //! 
 //! Contruct new caches using [`Default::default`], then construct/retrieve
-//! elements with `get`.
+//! elements with [`get`](Cache::get). `get` should only ever be used with one,
+//! `compute` function[^inconsistent].
 //! 
 //! In terms of choice, 
 //! - [`CopyCache`] should be used for expensive computations that create cheap
 //!   (i.e. small) values.
 //! - [`Cache`] should be used for expensive computations that create expensive
 //!   (i.e. large) values.
-//! - [`RecursionBreakingCache`] is the same as [`Cache`] except that it should
-//!   be used if the construction function for your values is going to call
-//!   `get` on the same cache. It detects if such a call is made with the same
-//!   key, which causes infinite recursion when [`Cache`] is used.
 //! 
-//! When in doubt the safest version is [`RecursionBreakingCache`] and if you
-//! don't anticipate recursion to occur you can always call `unwrap()` on it's
-//! result.
-
-use std::{cell::RefCell, hash::Hash, mem, pin::Pin};
+//! Both types of caches implement **recursion breaking**. In general because
+//! caches are supposed to be used as simple `&` (no `mut`) the reference may be
+//! freely copied, including into the `compute` closure. What this means is that
+//! a `compute` may call [`get`](Cache::get) on the cache again. This is usually
+//! safe and can be used to compute data structures that recursively depend on
+//! one another, dynamic-programming style. However if a `get` on a key `k`
+//! itself calls `get` again on the same `k` this will either create an infinite
+//! recursion or an inconsistent cache[^inconsistent].
+//! 
+//! Consider a simple example where we compute the Fibonacci Series with a
+//! [`CopyCache`]: 
+//! 
+//! ```rs
+//! let cache = CopyCache::default();
+//! let next_fib = |this| {
+//!   if this <= 1 { return this; }
+//!   let fib_1 = cache.get(this - 1, next_fib);
+//!   let fib_2 = cache.get(this - 2, next_fib);
+//!   fib_1 + fib_2
+//! };
+//! let fib_5 = cache.get(5, next_fib);
+//! ```
+//! 
+//! This use of recursive [`get`](CopyCache::get) calls is perfectly legal.
+//! However if we made an error and called `chache.get(this, ...)` (forgetting
+//! the decrement) we would have created an inadvertend infinite recursion.
+//! 
+//! To avoid this scenario both caches are implemented to detect when a
+//! recursive call as described is performed and `get` will panic. If your code
+//! uses recursive construction and would like to handle this case gracefully
+//! use [`get_maybe_recursive`](Cache::get_maybe_recursive) instead wich returns
+//! `None` from `get(k)` *iff* `k` this call (potentially transitively)
+//! originates from another `get(k)` call.
+//! 
+//! [^inconsistent]: For any given cache value `get` should only ever be used
+//!     with one, referentially transparent `compute` function. Essentially this
+//!     means running `compute(k)` should always return the same value
+//!     *independent of the state of it's environment*. Violation of this rule
+//!     can introduces non-determinism in your program.
+use std::{cell::RefCell, hash::Hash, pin::Pin};
 
 use rustc_data_structures::fx::FxHashMap as HashMap;
 
 /// Cache for non-copyable types.
-pub struct Cache<In, Out>(RefCell<HashMap<In, Pin<Box<Out>>>>);
+pub struct Cache<In, Out>(RefCell<HashMap<In, Option<Pin<Box<Out>>>>>);
 
 impl<In, Out> Cache<In, Out>
 where
@@ -34,79 +66,21 @@ where
   }
   /// Returns the cached value for the given key, or runs `compute` if
   /// the value is not in cache.
+  /// 
+  /// # Panics
+  /// 
+  /// Returns `None` if this is a recursive invocation of `get` for key `key`.
   pub fn get<'a>(&'a self, key: In, compute: impl FnOnce(In) -> Out) -> &'a Out {
-    if !self.0.borrow().contains_key(&key) {
-      let out = Box::pin(compute(key.clone()));
-      self.0.borrow_mut().insert(key.clone(), out);
-    }
-
-    let cache = self.0.borrow();
-    let entry_pin = cache.get(&key).unwrap();
-    let entry_ref = entry_pin.as_ref().get_ref();
-
-    // SAFETY: because the entry is pinned, it cannot move and this pointer will
-    // only be invalidated if Cache is dropped. The returned reference has a lifetime
-    // equal to Cache, so Cache cannot be dropped before this reference goes out of scope.
-    unsafe { mem::transmute::<&'_ Out, &'a Out>(entry_ref) }
-  }
-}
-
-impl<In, Out> Default for Cache<In, Out> {
-  fn default() -> Self {
-    Cache(RefCell::new(HashMap::default()))
-  }
-}
-
-/// Cache for copyable types.
-pub struct CopyCache<In, Out>(RefCell<HashMap<In, Out>>);
-
-impl<In, Out> CopyCache<In, Out>
-where
-  In: Hash + Eq + Clone,
-  Out: Copy,
-{
-  /// Size of the cache
-  pub fn len(&self) -> usize {
-    self.0.borrow().len()
+    self.get_maybe_recursive(key, compute).unwrap_or_else(recursion_panic)
   }
   /// Returns the cached value for the given key, or runs `compute` if
   /// the value is not in cache.
-  pub fn get(&self, key: In, compute: impl FnOnce(In) -> Out) -> Out {
-    let mut cache = self.0.borrow_mut();
-    *cache
-      .entry(key.clone())
-      .or_insert_with(move || compute(key))
-  }
-}
-
-impl<In, Out> Default for CopyCache<In, Out> {
-  fn default() -> Self {
-    CopyCache(RefCell::new(HashMap::default()))
-  }
-}
-
-/// This cache alters the [`Self::get`] method signature to return
-/// an [`Option`] of a reference. In particular the method will return [`None`]
-/// if it is called *with the same key* while computing a construction function
-/// for that key.
-pub struct RecursionBreakingCache<In, Out>(RefCell<HashMap<In, Option<Pin<Box<Out>>>>>);
-
-impl<In, Out> RecursionBreakingCache<In, Out>
-where
-  In: Hash + Eq + Clone,
-  Out: Unpin,
-{
-  /// Size of the cache
-  pub fn len(&self) -> usize {
-    self.0.borrow().len()
-  }
-  /// Get or compute the value for this key. Returns `None` if the `compute`
-  /// function calls this [`get`] function again *with the same key*. Calls to
-  /// [`get`] with different keys are allowed.
-  pub fn get<'a>(&'a self, key: In, compute: impl FnOnce(In) -> Out) -> Option<&'a Out> {
+  /// 
+  /// Returns `None` if this is a recursive invocation of `get` for key `key`.
+  pub fn get_maybe_recursive<'a>(&'a self, key: In, compute: impl FnOnce(In) -> Out) -> Option<&'a Out> {
     if !self.0.borrow().contains_key(&key) {
       self.0.borrow_mut().insert(key.clone(), None);
-      let out = Pin::new(Box::new(compute(key.clone())));
+      let out = Box::pin(compute(key.clone()));
       self.0.borrow_mut().insert(key.clone(), Some(out));
     }
 
@@ -122,9 +96,58 @@ where
   }
 }
 
-impl<In, Out> Default for RecursionBreakingCache<In, Out> {
+fn recursion_panic<A>() -> A {
+  panic!("Recursion detected! The computation of a value tried to retrieve the same from the cache. Using `get_maybe_recursive` to handle this case gracefully.")
+}
+
+impl<In, Out> Default for Cache<In, Out> {
   fn default() -> Self {
-    Self(RefCell::new(HashMap::default()))
+    Cache(RefCell::new(HashMap::default()))
+  }
+}
+
+/// Cache for copyable types.
+pub struct CopyCache<In, Out>(RefCell<HashMap<In, Option<Out>>>);
+
+impl<In, Out> CopyCache<In, Out>
+where
+  In: Hash + Eq + Clone,
+  Out: Copy,
+{
+  /// Size of the cache
+  pub fn len(&self) -> usize {
+    self.0.borrow().len()
+  }
+  /// Returns the cached value for the given key, or runs `compute` if
+  /// the value is not in cache.
+  /// 
+  /// # Panics
+  /// 
+  /// Returns `None` if this is a recursive invocation of `get` for key `key`.
+  pub fn get(&self, key: In, compute: impl FnOnce(In) -> Out) -> Out {
+    self.get_maybe_recursive(key, compute).unwrap_or_else(recursion_panic)
+  }
+
+  /// Returns the cached value for the given key, or runs `compute` if
+  /// the value is not in cache.
+  /// 
+  /// Returns `None` if this is a recursive invocation of `get` for key `key`.
+  pub fn get_maybe_recursive(&self, key: In, compute: impl FnOnce(In) -> Out) -> Option<Out> {
+    if !self.0.borrow().contains_key(&key) {
+      self.0.borrow_mut().insert(key.clone(), None);
+      let out = compute(key.clone());
+      self.0.borrow_mut().insert(key.clone(), Some(out));
+    }
+
+    *self.0.borrow_mut()
+      .get(&key)
+      .expect("invariant proken")
+  }
+}
+
+impl<In, Out> Default for CopyCache<In, Out> {
+  fn default() -> Self {
+    CopyCache(RefCell::new(HashMap::default()))
   }
 }
 


### PR DESCRIPTION
This adds a new type of `Cache` which breaks recursive `get` calls in the compute function by returning an `Option`.

Also adds a `len` method to gage the size of the cache.