### PR TITLE
Pass a hash of the modification date for cache control

### DIFF
--- a/crates/rustc_plugin/src/driver.rs
+++ b/crates/rustc_plugin/src/driver.rs
@@ -104,6 +104,16 @@ pub fn driver_main<T: RustcPlugin>(plugin: T) {
   exit(rustc_driver::catch_with_exit_code(move || {
     let mut orig_args: Vec<String> = env::args().collect();
 
+    let hash_check_arg = orig_args
+      .iter()
+      .enumerate()
+      .find(|elem| elem.1 == crate::EXEC_HASH_ARG)
+      .map(|t| t.0)
+      .unwrap();
+
+    orig_args.remove(hash_check_arg);
+    orig_args.remove(hash_check_arg);
+
     let (have_sys_root_arg, sys_root) = get_sysroot(&orig_args);
 
     if orig_args.iter().any(|a| a == "--version" || a == "-V") {

--- a/crates/rustc_plugin/src/lib.rs
+++ b/crates/rustc_plugin/src/lib.rs
@@ -8,6 +8,8 @@
 extern crate rustc_driver;
 extern crate rustc_interface;
 
+const EXEC_HASH_ARG: &str = "--exec-hash";
+
 #[doc(hidden)]
 pub use cargo_metadata::camino::Utf8Path;
 pub use cli::cli_main;


### PR DESCRIPTION
This passes an additional `--exec-hash` argument to rustc which contains a hash of the modification dates for both the cli and the driver application.

This invalidates the build cache when the plugin is recompiled.

**Caveats:** The argument is passed via (encoded) rustflags, which means we can't use `CARGO_WORKSPACE_WRAPPER` anymore, because we need the driver to filter out the `--exec-hash` argument before it hits regular rustc.