### PR TITLE
Add SilentEmitter for ignoring diagnostics.

### DIFF
--- a/crates/rustc_utils/src/errors/mod.rs
+++ b/crates/rustc_utils/src/errors/mod.rs
@@ -1,0 +1,1 @@
+pub mod silent_emitter;

--- a/crates/rustc_utils/src/errors/silent_emitter.rs
+++ b/crates/rustc_utils/src/errors/silent_emitter.rs
@@ -1,7 +1,6 @@
 //! Silent diagnostics emitter.
 //!
-//! See:
-//! https://doc.rust-lang.org/nightly/nightly-rustc/rustfmt_nightly/parse/session/struct.SilentEmitter.html#impl-Translate-for-SilentEmitter
+//! See: <https://doc.rust-lang.org/nightly/nightly-rustc/rustfmt_nightly/parse/session/struct.SilentEmitter.html#impl-Translate-for-SilentEmitter>
 
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{emitter::Emitter, translation::Translate, Diagnostic};

--- a/crates/rustc_utils/src/errors/silent_emitter.rs
+++ b/crates/rustc_utils/src/errors/silent_emitter.rs
@@ -1,0 +1,29 @@
+//! Silent diagnostics emitter.
+//!
+//! See:
+//! https://doc.rust-lang.org/nightly/nightly-rustc/rustfmt_nightly/parse/session/struct.SilentEmitter.html#impl-Translate-for-SilentEmitter
+
+use rustc_data_structures::sync::Lrc;
+use rustc_errors::{emitter::Emitter, translation::Translate, Diagnostic};
+use rustc_span::source_map::SourceMap;
+
+/// Emitter which discards every error.
+pub struct SilentEmitter;
+
+impl Translate for SilentEmitter {
+  fn fluent_bundle(&self) -> Option<&Lrc<rustc_errors::FluentBundle>> {
+    None
+  }
+
+  fn fallback_fluent_bundle(&self) -> &rustc_errors::FluentBundle {
+    panic!("silent emitter attempted to translate a diagnostic");
+  }
+}
+
+impl Emitter for SilentEmitter {
+  fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+    None
+  }
+
+  fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
+}

--- a/crates/rustc_utils/src/lib.rs
+++ b/crates/rustc_utils/src/lib.rs
@@ -28,6 +28,7 @@ extern crate either;
 extern crate rustc_borrowck;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_errors;
 extern crate rustc_graphviz;
 extern crate rustc_hir;
 extern crate rustc_index;
@@ -47,6 +48,7 @@ extern crate rustc_type_ir;
 extern crate smallvec;
 
 pub mod cache;
+pub mod errors;
 pub mod hir;
 pub mod mir;
 pub mod source_map;


### PR DESCRIPTION
Useful for plugins that ignore rustc diagnostics (e.g., Aquascope and Argus).