### PR TITLE
Update rust-toolchain.toml to use a channel that matches rustc_plugin…

### DIFF
--- a/crates/rustc_plugin/examples/print-all-items/rust-toolchain.toml
+++ b/crates/rustc_plugin/examples/print-all-items/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-08-25"
+channel = "nightly-2024-01-24"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
…'s channel.