### PR TITLE
Refactoring region visitor

### DIFF
--- a/crates/rustc_utils/src/mir/place.rs
+++ b/crates/rustc_utils/src/mir/place.rs
@@ -1,6 +1,6 @@
 //! Utilities for [`Place`].
 
-use std::{borrow::Cow, collections::VecDeque, ops::ControlFlow};
+use std::{borrow::Cow, collections::VecDeque};
 
 use log::{trace, warn};
 use rustc_data_structures::fx::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -724,7 +724,7 @@ struct Point { x: usize, y: usize }
 fn main() {
   let x = (0, 0);
   let y = Some(1);
-  let z = &[Some((0, 1))];    
+  let z = &[Some((0, 1))];
   let w = (&y,);
   let p = &Point { x: 0, y: 0 };
 }


### PR DESCRIPTION
Replaces the two `Option` fields with a generic argument. This avoids the `unwrap()`s in the `PlaceExt` methods and I thin it makes the code more straighforward to understand.

I also took the liberty to change the type signatures to `HashSet`, because the order of these elements makes no difference, in fact the guarantee that the returned places are deduplicated is more important.