### PR TITLE
Guard against race on MIR_BODIES in tests

### DIFF
--- a/crates/rustc_utils/src/mir/borrowck_facts.rs
+++ b/crates/rustc_utils/src/mir/borrowck_facts.rs
@@ -80,8 +80,8 @@ thread_local! {
   static MIR_BODIES: Cache<CacheKey, BodyWithBorrowckFacts<'static>> = Cache::default();
 }
 
-fn make_key(_tcx: TyCtxt<'_>, def_id: LocalDefId) -> CacheKey {
-  (def_id, std::ptr::addr_of!(*_tcx) as usize)
+fn make_key(tcx: TyCtxt<'_>, def_id: LocalDefId) -> CacheKey {
+  (def_id, *tcx as *const _ as usize)
 }
 
 fn mir_borrowck(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &BorrowCheckResult<'_> {


### PR DESCRIPTION
In test cases multiple `TyCtxt`s may be live and assigning the same id's to functions. This can cause a race on the `static` that persists the MIR bodies.

This PR mitigates this by extending the cache key with the address of the global context, which is unlikely to be assigned twice. 