### PR TITLE
Add sym link to `rust-toolchain.toml` to fix rust-analyzer errors

### DIFF
--- a/crates/rustc_utils/rust-toolchain.toml
+++ b/crates/rustc_utils/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../../rust-toolchain.toml


### PR DESCRIPTION
`rust-analyzer` needs to have next to the `Cargo.toml` the `rust-toolchain.toml` file in order to semantically highlight the `extern crate rustc_*`.