### PR TITLE
feat: Bump rust toolchain for rustc 1.82 in rustc_plugin 🚧 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 The Rust compiler's interface is not stable, so the only sensible way to develop a Rust compiler plugin is by pinning to a specific nightly. Each version of `rustc_plugin` is pinned to one nightly, and you *have* to use the same nightly version that we do. Therefore each release of `rustc_plugin` has a semantic version number (e.g. `0.1.0`) and the nightly version is added as a prerelease label (e.g. `-nightly-2023-08-25`). You can add a dependency to your `Cargo.toml` like this:
  
 ```toml
-rustc_plugin = "=0.10.0-nightly-2024-05-20"
+rustc_plugin = "=0.11.0-nightly-2024-11-05"
 ```
 
 We will treat a change to the nightly version as a breaking change, so the semantic version will be correspondingly updated as a breaking update.
@@ -44,6 +44,7 @@ The `rustc_plugin` framework is responsible for marshalling arguments from the t
 
 Normally, Rust libraries have a [minimum supported Rust version][msrv] because they promise to not use any breaking features implemented after that version. Rust compiler plugins are the opposite &mdash; they have a **maximum** supported Rust version (MaxSRV). A compiler plugin cannot analyze programs that use features implemented after the release date of the plugin's toolchain. The MaxSRV for every version of `rustc_plugin` is listed below:
 
+* v0.11 (`nightly-2024-11-05`) - rustc 1.82
 * v0.10 (`nightly-2024-05-20`) - rustc 1.79
 * v0.9 (`nightly-2024-01-24`) - rustc 1.76
 * v0.8 (`nightly-2024-01-06`) - rustc 1.76
@@ -55,7 +56,7 @@ Normally, Rust libraries have a [minimum supported Rust version][msrv] because t
 [Aquascope]: https://github.com/cognitive-engineering-lab/aquascope
 [Clippy]: https://github.com/rust-lang/rust-clippy
 [example]: https://github.com/cognitive-engineering-lab/rustc_plugin/tree/main/crates/rustc_plugin/examples/print-all-items
-[docs]: https://cognitive-engineering-lab.github.io/rustc_plugin/v0.10.0-nightly-2024-05-20/rustc_plugin/
-[docs-utils]: https://cognitive-engineering-lab.github.io/rustc_plugin/v0.10.0-nightly-2024-05-20/rustc_utils/
+[docs]: https://cognitive-engineering-lab.github.io/rustc_plugin/v0.11.0-nightly-2024-11-05/rustc_plugin/
+[docs-utils]: https://cognitive-engineering-lab.github.io/rustc_plugin/v0.11.0-nightly-2024-11-05/rustc_utils/
 [msrv]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
 

--- a/crates/rustc_plugin/Cargo.toml
+++ b/crates/rustc_plugin/Cargo.toml
@@ -18,7 +18,7 @@ serde = "1"
 serde_json = "1"
 
 [dev-dependencies]
-anyhow = {version = "1", features = ["backtrace"]}
+anyhow = { version = "1", features = ["backtrace"] }
 
 [build-dependencies]
 toml = "0.7"

--- a/crates/rustc_plugin/Cargo.toml
+++ b/crates/rustc_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_plugin"
-version = "0.10.0-nightly-2024-05-20"
+version = "0.11.0-nightly-2024-11-05"
 edition = "2021"
 authors = ["Will Crichton <crichton.will@gmail.com>"]
 description = "A framework for writing plugins that integrate with the Rust compiler"
@@ -13,7 +13,7 @@ rustc_private = true
 [dependencies]
 rustc_tools_util = "0.1"
 log = "0.4"
-cargo_metadata = "0.14"
+cargo_metadata = "0.18.1"
 serde = "1"
 serde_json = "1"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-20"
+channel = "nightly-2024-11-05"
 components = ["clippy", "rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
I was going to update `rustc_utils` too but `MirPass` is no longer public (not sure if on purpose) https://github.com/rust-lang/rust/pull/129926